### PR TITLE
fix(command): trim command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         entry: goimports
         files: \.go$
         additional_dependencies:
-        - golang.org/x/tools/cmd/goimports@latest
+        - golang.org/x/tools/cmd/goimports@v0.24.0
         args:
         - -w
         require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,8 @@ repos:
         language: golang
         entry: goimports
         files: \.go$
+        additional_dependencies:
+        - golang.org/x/tools/cmd/goimports@latest
         args:
         - -w
         require_serial: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "go.lintTool": "golangci-lint",
     "go.lintFlags": [
         "--fast"
-    ]
+    ],
+    "go.testTimeout": "600s"
 }

--- a/chunk.go
+++ b/chunk.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pierrec/lz4"
@@ -362,6 +363,8 @@ func (this *SQCloud) sendArray(command string, values []interface{}) (int, error
 			return 0, err
 		}
 	}
+
+	command = strings.Trim(command, " \t\r\n")
 
 	// convert values to buffers encoded with whe sqlitecloud protocol
 	buffers := [][]byte{protocolBufferFromString(command, true)[0]}

--- a/chunk.go
+++ b/chunk.go
@@ -287,6 +287,8 @@ func (this *SQCloud) sendString(data string) (int, error) {
 		}
 	}
 
+	data = strings.Trim(data, " \t\r\n")
+
 	rawBuffer := protocolBufferFromString(data, false)[0]
 	bytesToSend = len(rawBuffer)
 

--- a/test/compress_test.go
+++ b/test/compress_test.go
@@ -127,3 +127,24 @@ func TestCompress(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 }
+
+func TestRowsetChunkCompressed(t *testing.T) {
+	var db *sqlitecloud.SQCloud
+	var err error
+
+	connectionString, _ := os.LookupEnv("SQLITE_CONNECTION_STRING")
+	apikey, _ := os.LookupEnv("SQLITE_API_KEY")
+	if db, err = sqlitecloud.Connect(connectionString + "?apikey=" + apikey); err != nil {
+		t.Fatal("CONNECT: ", err.Error())
+	}
+	defer db.Close()
+
+	switch res, err := db.Select("TEST ROWSET_CHUNK_COMPRESSED"); { // ROWSET
+	case err != nil:
+		t.Fatal("TEST ROWSET_CHUNK_COMPRESSED: ", err.Error())
+	case res == nil:
+		t.Fatal("TEST ROWSET_CHUNK_COMPRESSED: nil result")
+	case !res.IsRowSet():
+		t.Fatal("TEST ROWSET_CHUNK_COMPRESSED: invalid type")
+	}
+}

--- a/test/select_test.go
+++ b/test/select_test.go
@@ -1,0 +1,76 @@
+package test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sqlitecloud/sqlitecloud-go"
+)
+
+func TestSelectWithLeadingChars(t *testing.T) {
+	// Server API test
+	connectionString, _ := os.LookupEnv("SQLITE_CONNECTION_STRING")
+	apikey, _ := os.LookupEnv("SQLITE_API_KEY")
+	connectionString += "/" + os.Getenv("SQLITE_DB") + "?apikey=" + apikey
+
+	config, err1 := sqlitecloud.ParseConnectionString(connectionString)
+	if err1 != nil {
+		t.Fatal(err1.Error())
+	}
+
+	db := sqlitecloud.New(*config)
+	err := db.Connect()
+
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	defer db.Close()
+
+	// test select with leading spaces
+	result, err := db.Select("     SELECT 1 AS value;")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if result.GetNumberOfRows() != 1 {
+		t.Fatalf("Expected 1 row, got %d rows", result.GetNumberOfRows())
+	}
+
+	// test select with leading tabs
+	result, err = db.Select("\t\t\tSELECT 1 AS value;")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if result.GetNumberOfRows() != 1 {
+		t.Fatalf("Expected 1 row, got %d rows", result.GetNumberOfRows())
+	}
+
+	// test select with leading new lines
+	result, err = db.Select("\n\n\nSELECT 1 AS value;")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if result.GetNumberOfRows() != 1 {
+		t.Fatalf("Expected 1 row, got %d rows", result.GetNumberOfRows())
+	}
+
+	// test with leading carriage returns
+	result, err = db.Select("\r\r\rSELECT 1 AS value;")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if result.GetNumberOfRows() != 1 {
+		t.Fatalf("Expected 1 row, got %d rows", result.GetNumberOfRows())
+	}
+
+	// test select with mixed leading characters
+	result, err = db.Select(`
+		SELECT 1 AS value;
+	`)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if result.GetNumberOfRows() != 1 {
+		t.Fatalf("Expected 1 row, got %d rows", result.GetNumberOfRows())
+	}
+}

--- a/test/selectarray_test.go
+++ b/test/selectarray_test.go
@@ -141,3 +141,71 @@ func TestSelectArrayTableNameWithQuotes(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 }
+
+func TestSelectArrayWithLeadingChars(t *testing.T) {
+	// Server API test
+	connectionString, _ := os.LookupEnv("SQLITE_CONNECTION_STRING")
+	apikey, _ := os.LookupEnv("SQLITE_API_KEY")
+	connectionString += "/" + os.Getenv("SQLITE_DB") + "?apikey=" + apikey
+
+	config, err1 := sqlitecloud.ParseConnectionString(connectionString)
+	if err1 != nil {
+		t.Fatal(err1.Error())
+	}
+
+	db := sqlitecloud.New(*config)
+	err := db.Connect()
+
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	defer db.Close()
+
+	// test select with leading spaces
+	result, err := db.SelectArray("     SELECT 1 AS value;", nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if result.GetNumberOfRows() != 1 {
+		t.Fatalf("Expected 1 row, got %d rows", result.GetNumberOfRows())
+	}
+
+	// test select with leading tabs
+	result, err = db.SelectArray("\t\t\tSELECT 1 AS value;", nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if result.GetNumberOfRows() != 1 {
+		t.Fatalf("Expected 1 row, got %d rows", result.GetNumberOfRows())
+	}
+
+	// test select with leading new lines
+	result, err = db.SelectArray("\n\n\nSELECT 1 AS value;", nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if result.GetNumberOfRows() != 1 {
+		t.Fatalf("Expected 1 row, got %d rows", result.GetNumberOfRows())
+	}
+
+	// test with leading carriage returns
+	result, err = db.SelectArray("\r\r\rSELECT 1 AS value;", nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if result.GetNumberOfRows() != 1 {
+		t.Fatalf("Expected 1 row, got %d rows", result.GetNumberOfRows())
+	}
+
+	// test select with mixed leading characters
+	result, err = db.SelectArray(`
+		SELECT 1 AS value;
+	`, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if result.GetNumberOfRows() != 1 {
+		t.Fatalf("Expected 1 row, got %d rows", result.GetNumberOfRows())
+	}
+}


### PR DESCRIPTION
With trailing/leading empty chars the command parse failed to execute the proper query.

PS: Added a pending test `func TestRowsetChunkCompressed(t *testing.T) {`.